### PR TITLE
:lipstick: [FLAV-117] Add color codes (starbucks)

### DIFF
--- a/src/data/color_codes
+++ b/src/data/color_codes
@@ -1,0 +1,17 @@
+#000
+#43a328
+#5f4e44
+#64b72f
+#90847c
+#91877e
+#aaa
+#b1aba7
+#bcb5b1
+#c7c0b9
+#ccc7c1
+#e2ddd7
+#e2ded7
+#e2ded8
+#e7e5e3
+#eeebe8
+#fff


### PR DESCRIPTION
@Hironori8 @yukFuruya スタバのカラーコード一覧を追加しました．ソースコードに気軽にコピペできたほうが良いと思うのでコード内に含めてしまっています．
CSSのグローバルスタイルを定義した後にこのファイルは削除の予定です．